### PR TITLE
Fix for new firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 The repository contains the source code for the LibNbiot, which allows to access the
 **Telekom Cloud of Things** with **NB-IoT** radio modules.
 
+**NOTICE**: The newest commit only supports the new syntax of firmware **B657SP3** and greater. If your module has the older firmware **B656**, please update the firmware of your module or revert to commit ed399bb3073868019978e2174a9599301f5a2771.
+
+
 ## Building from command line
 
 The library relieas on [GNU Make](https://www.gnu.org/software/make/) as build system. After downloading it can

--- a/libNbiotCore/include/nbiotstring.h
+++ b/libNbiotCore/include/nbiotstring.h
@@ -25,334 +25,341 @@
 
 namespace nbiot {
 
-class StringList;
+    class StringList;
 
-unsigned char h2c(char);
-char c2h(unsigned char);
+    unsigned char h2c(char);
+    char c2h(unsigned char);
 
-class string
-{
-public:
-    /*!
-     * \brief string constructs an empty string. Allocates one byte for the terminating zero in data.
-     */
-    string();
-    /*!
-     * \brief string copy constructor
-     * \param str
-     */
-    string(const string& str);
-    /*!
-     * \brief string
-     * \param str
-     * \param len
-     */
-    string(const char* str, size_t len = npos);
-    /*!
-     *
-     *
-     */
-    ~string();
-
-    /*!
-     * \brief operator =
-     * \param str
-     * \return
-     */
-    string& operator = (const string& str);
-    /*!
-     * \brief operator =
-     * \param str
-     * \return
-     */
-    string& operator = (const char* str);
-
-    /*!
-     * \brief operator +=
-     * \param str
-     * \return
-     */
-    string& operator += (const string& str)
+    class string
     {
-        append(str);
-        return *this;
-    }
+    public:
+        /*!
+         * \brief string constructs an empty string. Allocates one byte for the terminating zero in data.
+         */
+        string();
+        /*!
+         * \brief string copy constructor
+         * \param str
+         */
+        string(const string& str);
+        /*!
+         * \brief string
+         * \param str
+         * \param len
+         */
+        string(const char* str, size_t len = npos);
+        /*!
+         *
+         *
+         */
+        ~string();
 
-    /*!
-     * \brief operator +=
-     * \param str
-     * \return
-     */
-    string& operator += (const char* str)
-    {
-        append(str);
-        return *this;
-    }
+        /*!
+         * \brief operator =
+         * \param str
+         * \return
+         */
+        string& operator = (const string& str);
+        /*!
+         * \brief operator =
+         * \param str
+         * \return
+         */
+        string& operator = (const char* str);
 
-    /*!
-     * \brief operator +=
-     * \param c
-     * \return
-     */
-    string& operator += (const char c)
-    {
-        push_back(c);
-        return *this;
-    }
-
-    /*!
-     * \brief operator ==
-     * \param str
-     * \return
-     */
-    bool operator == (const string& str) const
-    {
-        return *this == str.data;
-    }
-
-    /*!
-     * \brief operator ==
-     * \param str
-     * \return
-     */
-    bool operator == (const char* str) const;
-
-    /*!
-     * \brief operator []
-     * \param index
-     * \return
-     */
-    char operator [](size_t index) const
-    {
-        if((sz > index))
+        /*!
+         * \brief operator +=
+         * \param str
+         * \return
+         */
+        string& operator += (const string& str)
         {
-            return data[index];
+            append(str);
+            return *this;
         }
-        else
+
+        /*!
+         * \brief operator +=
+         * \param str
+         * \return
+         */
+        string& operator += (const char* str)
         {
-            return 0;
+            append(str);
+            return *this;
         }
-    }
 
-    /*!
-     * \brief at
-     * \param index
-     * \return
-     */
-    char at(size_t index) const
-    {
-        if((sz > index))
+        /*!
+         * \brief operator +=
+         * \param c
+         * \return
+         */
+        string& operator += (const char c)
         {
-            return data[index];
+            push_back(c);
+            return *this;
         }
-        else
+
+        /*!
+         * \brief operator ==
+         * \param str
+         * \return
+         */
+        bool operator == (const string& str) const
         {
-            return 0;
+            return *this == str.data;
         }
-    }
 
-    /*!
-     * \brief c_str
-     * \return
-     */
-    const char* c_str() const
-    {
-        return data;
-    }
+        /*!
+         * \brief operator ==
+         * \param str
+         * \return
+         */
+        bool operator == (const char* str) const;
 
-    /*!
-     * \brief getData
-     * \return
-     */
-    char* getData()
-    {
-        return data;
-    }
+        /*!
+         * \brief operator []
+         * \param index
+         * \return
+         */
+        char operator [](size_t index) const
+        {
+            if((sz > index))
+            {
+                return data[index];
+            }
+            else
+            {
+                return 0;
+            }
+        }
 
-    /*!
-     * \brief size
-     * \return
-     */
-    size_t size() const
-    {
-        return sz;
-    }
+        /*!
+         * \brief at
+         * \param index
+         * \return
+         */
+        char at(size_t index) const
+        {
+            if((sz > index))
+            {
+                return data[index];
+            }
+            else
+            {
+                return 0;
+            }
+        }
 
-    /*!
-     * \brief empty
-     * \return
-     */
-    bool empty() const
-    {
-        return (0 == sz);
-    }
+        /*!
+         * \brief c_str
+         * \return
+         */
+        const char* c_str() const
+        {
+            return data;
+        }
 
-    /*!
-     * \brief push_back
-     * \param c
-     */
-    void push_back(char c);
-    /*!
-     * \brief take_front
-     * \return
-     */
-    char take_front();
-    /*!
-     * \brief find
-     * \param str
-     * \return
-     */
-    size_t find(const string& str) const
-    {
-        return find(str.data);
-    }
-    /*!
-     * \brief find
-     * \param str
-     * \return
-     */
-    size_t find(const char* str) const;
-    /*!
-     * \brief find
-     * \param c
-     * \return
-     */
-    size_t find(const char c) const;
-    /*!
-     * \brief substr
-     * \param pos
-     * \param len
-     * \return
-     */
-    string substr (size_t pos = 0, size_t len = npos) const;
+        /*!
+         * \brief getData
+         * \return
+         */
+        char* getData()
+        {
+            return data;
+        }
 
-    /*!
-     * \brief append
-     * \param str
-     * \param len
-     */
-    void append(const char* str, size_t len = npos);
-    /*!
-     * \brief append
-     * \param str
-     */
-    void append(const string& str);
+        /*!
+         * \brief size
+         * \return
+         */
+        size_t size() const
+        {
+            return sz;
+        }
 
-    /*!
-     * \brief split
-     * \param sep
-     * \param keepSeparator
-     * \return
-     */
-    StringList split(char sep, bool keepSeparator=false) const;
-    /*!
-     * \brief split
-     * \param sep
-     * \param keepSeparator
-     * \return
-     */
-    StringList split(const char* sep, bool keepSeparator=false) const;
+        /*!
+         * \brief empty
+         * \return
+         */
+        bool empty() const
+        {
+            return (0 == sz);
+        }
 
-    /*!
-     * \brief compareNoCase
-     * \param str
-     * \return
-     */
-    bool compareNoCase(const char* str) const;
+        /*!
+         * \brief push_back
+         * \param c
+         */
+        void push_back(char c);
+        /*!
+         * \brief take_front
+         * \return
+         */
+        char take_front();
+        /*!
+         * \brief find
+         * \param str
+         * \return
+         */
+        size_t find(const string& str) const
+        {
+            return find(str.data);
+        }
+        /*!
+         * \brief find
+         * \param str
+         * \return
+         */
+        size_t find(const char* str) const;
+        /*!
+         * \brief find
+         * \param c
+         * \return
+         */
+        size_t find(const char c) const;
+        /*!
+         * \brief substr
+         * \param pos
+         * \param len
+         * \return
+         */
+        string substr (size_t pos = 0, size_t len = npos) const;
 
-    /*!
-     * \brief copy copies string content to a char pointer destination. The memory at the destination must be allocated before.
-     * \param dest destination char*
-     * \param len maximum bytes to copy. The destination needs one more byte of space for the terminating zero.
-     * \return number of copied bytes
-     *
-     * Example:
-     * \code
-     * char chPtr[16];
-     * string str("Hello World!");
-     *
-     * size_t copied = str.copy(chPtr, 15); // max 15 bytes
-     * \endcode
-     */
-    size_t copy(char* dest, size_t len) const;
+        /*!
+         * \brief append
+         * \param str
+         * \param len
+         */
+        void append(const char* str, size_t len = npos);
+        /*!
+         * \brief append
+         * \param str
+         */
+        void append(const string& str);
 
-    /*!
-     * \brief copy copies string content to an unsigned char pointer destination. The memory at the destination must be allocated before.
-     * \param dest destination unsigned char*
-     * \param len maximum bytes to copy. The destination needs one more byte of space for the terminating zero.
-     * \return number of copied bytes
-     */
-    size_t copy(unsigned char* dest, size_t len) const;
+        /*!
+         * \brief split
+         * \param sep
+         * \param keepSeparator
+         * \return
+         */
+        StringList split(char sep, bool keepSeparator=false) const;
+        /*!
+         * \brief split
+         * \param sep
+         * \param keepSeparator
+         * \return
+         */
+        StringList split(const char* sep, bool keepSeparator=false) const;
 
-    /*!
-     * \brief toHex
-     * \return
-     */
-    string toHex() const;
+        /*!
+         * \brief compareNoCase
+         * \param str
+         * \return
+         */
+        bool compareNoCase(const char* str) const;
 
-    /*!
-     * \brief join
-     * \param list
-     * \param pos
-     * \param len
-     * \return
-     */
-    static string join(StringList list, size_t pos = 0, size_t len = npos);
+        /*!
+         * \brief copy copies string content to a char pointer destination. The memory at the destination must be allocated before.
+         * \param dest destination char*
+         * \param len maximum bytes to copy. The destination needs one more byte of space for the terminating zero.
+         * \return number of copied bytes
+         *
+         * Example:
+         * \code
+         * char chPtr[16];
+         * string str("Hello World!");
+         *
+         * size_t copied = str.copy(chPtr, 15); // max 15 bytes
+         * \endcode
+         */
+        size_t copy(char* dest, size_t len) const;
 
-    /*!
-     * \brief fromHex
-     * \param hex
-     * \return
-     */
-    static string fromHex(const char* hex);
+        /*!
+         * \brief copy copies string content to an unsigned char pointer destination. The memory at the destination must be allocated before.
+         * \param dest destination unsigned char*
+         * \param len maximum bytes to copy. The destination needs one more byte of space for the terminating zero.
+         * \return number of copied bytes
+         */
+        size_t copy(unsigned char* dest, size_t len) const;
 
-    /*!
-     * \brief Printf
-     * \param format
-     * \return
-     */
-    static string Printf(const char* format, ...);
+        /*!
+         * \brief toHex
+         * \return
+         */
+        string toHex() const;
 
-    /*!
-     * \brief npos
-     */
-    static const size_t	npos;// = static_cast<size_t>(-1);
+        /*!
+         * \brief join
+         * \param list
+         * \param pos
+         * \param len
+         * \return
+         */
+        static string join(StringList list, size_t pos = 0, size_t len = npos);
 
-    // if you write directly to data, you need to set the size after
-    /*!
-     * \brief setSize
-     * \param len
-     */
-    void setSize(size_t len) { if(len < mem_size) { sz = len; } }
-    
-    /*!
-     * \brief check7bit
-     * \return
-     */
-    bool check7bit() const;
+        /*!
+         * \brief fromHex
+         * \param hex
+         * \return
+         */
+        static string fromHex(const char* hex);
 
-    /*!
-     * \brief toLower
-     * \return
-     */
-    string toLower() const;
+        /*!
+         * \brief Printf
+         * \param format
+         * \return
+         */
+        static string Printf(const char* format, ...);
 
-    /*!
-     * \brief valid
-     * \return
-     */
-    bool valid() const { return (nullptr != data); }
+        /*!
+         * \brief npos
+         */
+        static const size_t	npos;// = static_cast<size_t>(-1);
 
-private:
-    void clear();
-    void dup(const char* str, size_t len = npos);
+        // if you write directly to data, you need to set the size after
+        /*!
+         * \brief setSize
+         * \param len
+         */
+        void setSize(size_t len) { if(len < mem_size) { sz = len; } }
 
-    char* data;
-    size_t sz;
-    size_t mem_size;
+        /*!
+         * \brief check7bit
+         * \return
+         */
+        bool check7bit() const;
 
-    static const size_t PRINTF_BUFFER_SIZE = 80;
-};
+        /*!
+         * \brief toLower
+         * \return
+         */
+        string toLower() const;
+
+        /*!
+         * \brief strip
+         * \param c
+         * \return
+         */
+        string strip(char c) const;
+
+        /*!
+         * \brief valid
+         * \return
+         */
+        bool valid() const { return (nullptr != data); }
+
+    private:
+        void clear();
+        void dup(const char* str, size_t len = npos);
+
+        char* data;
+        size_t sz;
+        size_t mem_size;
+
+        static const size_t PRINTF_BUFFER_SIZE = 80;
+    };
 
 }
 

--- a/libNbiotCore/src/nbiotconnectivity.cpp
+++ b/libNbiotCore/src/nbiotconnectivity.cpp
@@ -26,10 +26,10 @@
 
 #include "nbiotconnectivity.h"
 
-const char* NbiotConnectivity::cmdNSOCR_arg = "AT+NSOCR=DGRAM,17,%d\r";
-const char* NbiotConnectivity::respNSONMI_arg = "+NSONMI:%d,";
+const char* NbiotConnectivity::cmdNSOCR_arg = "AT+NSOCR=\"DGRAM\",17,%d\r";
+const char* NbiotConnectivity::respNSONMI_arg = "+NSONMI: %d,";
 const char* NbiotConnectivity::cmdNSORF_arg = "AT+NSORF=%d,%d\r";
-const char* NbiotConnectivity::cmdNSOST_arg = "AT+NSOST=%d,%s,%d,%d,";
+const char* NbiotConnectivity::cmdNSOST_arg = "AT+NSOST=%d,\"%s\",%d,%d,\"";
 const char* NbiotConnectivity::cmdNSOCL_arg = "AT+NSOCL=%d\r";
 
 NbiotConnectivity::NbiotConnectivity(Serial& serial) :
@@ -216,7 +216,7 @@ int NbiotConnectivity::ipRead(nbiot::string& data, int len, unsigned short timeo
                         avail = atoi(list[nsorfRespIdx_bytesAvail].c_str());
                         if((0 < avail) && (avail <= len))
                         {
-                            data.append(nbiot::string::fromHex(list[nsorfRespIdx_data].c_str()));
+                            data.append(nbiot::string::fromHex(list[nsorfRespIdx_data].strip('"').c_str()));
                             m_bytesAvail = static_cast<size_t>(atoi(list[nsorfRespIdx_bytesRem].c_str()));
                         }
                     }
@@ -239,7 +239,8 @@ bool NbiotConnectivity::write(unsigned char* buffer, unsigned long len, unsigned
         nbiot::string data = nbiot::string::Printf(cmdNSOST_arg, m_connectionNumber, m_hostname.c_str(), m_port, len);
         nbiot::string hex = nbiot::string((char*)(buffer), len).toHex();
         data += hex;
-        #ifdef DEBUG_MODEM
+        data += "\"";
+#ifdef DEBUG_MODEM
 #ifdef DEBUG_COLOR
         debugPrintf("\033[0;32m[ MODEM    ]\033[0m ");
 #endif

--- a/libNbiotCore/src/nbiotstring.cpp
+++ b/libNbiotCore/src/nbiotstring.cpp
@@ -28,492 +28,526 @@
 
 namespace nbiot {
 
-unsigned char h2c(char c)
-{
-    unsigned char ret = 0;
-    if(('0' <= c) && ('9' >= c))
+    unsigned char h2c(char c)
     {
-        ret = c - '0';
+        unsigned char ret = 0;
+        if(('0' <= c) && ('9' >= c))
+        {
+            ret = c - '0';
+        }
+        else if (('a' <= c) && ('f' >= c)) {
+            ret = c - 'a' + 0x0a;
+        }
+        else if (('A' <= c) && ('F' >= c)) {
+            ret = c - 'A' + 0x0a;
+        }
+        return ret;
     }
-    else if (('a' <= c) && ('f' >= c)) {
-        ret = c - 'a' + 0x0a;
-    }
-    else if (('A' <= c) && ('F' >= c)) {
-        ret = c - 'A' + 0x0a;
-    }
-    return ret;
-}
 
-char c2h(unsigned char c)
-{
-    char ret = '0';
-    if(9 >= c)
+    char c2h(unsigned char c)
     {
-        ret += c;
+        char ret = '0';
+        if(9 >= c)
+        {
+            ret += c;
+        }
+        else if((0xa <= c) && (0xf >= c))
+        {
+            ret = 'A' + (c - 0xa);
+        }
+        return ret;
     }
-    else if((0xa <= c) && (0xf >= c))
-    {
-        ret = 'A' + (c - 0xa);
-    }
-    return ret;
-}
 
-const size_t string::npos = static_cast<size_t>(-1);
+    const size_t string::npos = static_cast<size_t>(-1);
 
 // constructs an empty zero terminated string
-string::string() :
-    data(NULL),
-    sz(0),
-    mem_size(0)
-{
-    data = (char*)malloc(sizeof(char));
-    if(NULL != data)
+    string::string() :
+            data(NULL),
+            sz(0),
+            mem_size(0)
     {
-        data[0] = 0;
-        mem_size = sizeof(char);
-#ifdef DEBUG_STRING
-        stringMem++;
-#endif
-    }
-}
-
-string::string(const string& str) :
-    data(NULL),
-    sz(0),
-    mem_size(0)
-{
-    dup(str.data, str.sz);
-}
-
-string::string(const char* str, size_t len) :
-    data(NULL),
-    sz(0),
-    mem_size(0)
-{
-    dup(str, len);
-}
-
-string::~string()
-{
-    free(data);
-#ifdef DEBUG_STRING
-    stringMem -= (sz + 1);
-#endif
-}
-
-string& string::operator = (const string& str)
-{
-    dup(str.data, str.sz);
-    return *this;
-}
-
-string& string::operator = (const char* str)
-{
-    dup(str);
-    return *this;
-}
-
-bool string::operator == (const char* str) const
-{
-    bool ret = false;
-    if((NULL == data) && NULL == str)
-    {
-        ret = true;
-    }
-    else
-    {
-        if((NULL != data) && NULL != str)
+        data = (char*)malloc(sizeof(char));
+        if(NULL != data)
         {
-            if(0 == strcmp(data, str))
-            {
-                ret = true;
-            }
+            data[0] = 0;
+            mem_size = sizeof(char);
+#ifdef DEBUG_STRING
+            stringMem++;
+#endif
         }
     }
-    return ret;
-}
 
-void string::push_back(char c)
-{
-    size_t newSize = sz + 1;
-    newSize++; // terminating zero
-
-    char* tmp = (char*)realloc(data, newSize * sizeof(char));
-    if(NULL != tmp)
+    string::string(const string& str) :
+            data(NULL),
+            sz(0),
+            mem_size(0)
     {
-        tmp[sz] = c;
-        tmp[sz + 1] = 0;
-        data = tmp;
-        sz++;
-        mem_size = newSize;
+        dup(str.data, str.sz);
+    }
+
+    string::string(const char* str, size_t len) :
+            data(NULL),
+            sz(0),
+            mem_size(0)
+    {
+        dup(str, len);
+    }
+
+    string::~string()
+    {
+        free(data);
 #ifdef DEBUG_STRING
-        stringMem++;
+        stringMem -= (sz + 1);
 #endif
     }
+
+    string& string::operator = (const string& str)
+    {
+        dup(str.data, str.sz);
+        return *this;
+    }
+
+    string& string::operator = (const char* str)
+    {
+        dup(str);
+        return *this;
+    }
+
+    bool string::operator == (const char* str) const
+    {
+        bool ret = false;
+        if((NULL == data) && NULL == str)
+        {
+            ret = true;
+        }
+        else
+        {
+            if((NULL != data) && NULL != str)
+            {
+                if(0 == strcmp(data, str))
+                {
+                    ret = true;
+                }
+            }
+        }
+        return ret;
+    }
+
+    void string::push_back(char c)
+    {
+        size_t newSize = sz + 1;
+        newSize++; // terminating zero
+
+        char* tmp = (char*)realloc(data, newSize * sizeof(char));
+        if(NULL != tmp)
+        {
+            tmp[sz] = c;
+            tmp[sz + 1] = 0;
+            data = tmp;
+            sz++;
+            mem_size = newSize;
 #ifdef DEBUG_STRING
-    else
+            stringMem++;
+#endif
+        }
+#ifdef DEBUG_STRING
+        else
     {
         debugPrintf("CAN'T REALLOC MEMORY (%d bytes)\r\n", newSize);
     }
 #endif
-}
-
-char string::take_front()
-{
-    char ret = 0;
-    if(0 < sz)
-    {
-        ret = data[0];
-        sz--;
-        if(0 == sz)
-        {
-            clear();
-        }
-        else
-        {
-            memmove(data, &data[1], sz);
-            data[sz] = 0;
-        }
-    }
-    return ret;
-}
-
-size_t string::find(const char* str) const
-{
-    size_t result = npos;
-    if(valid() && (nullptr != str))
-    {
-        const char* found = strstr(data, str);
-        if(NULL != found)
-        {
-            result = static_cast<size_t>(found - data);
-        }
-    }
-    return result;
-}
-
-size_t string::find(const char c) const
-{
-    size_t result = npos;
-    if(valid())
-    {
-        const char* found = strchr(data, static_cast<int>(c));
-        if(NULL != found)
-        {
-            result = static_cast<size_t>(found - data);
-        }
-    }
-    return result;
-}
-
-string string::substr (size_t pos, size_t len) const
-{
-    if(sz <= pos)
-    {
-        return string();
-    }
-    if(sz < (pos + len))
-    {
-        len = sz - pos;
-    }
-    return string(&data[pos], len);
-}
-
-void string::append(const char* str, size_t len)
-{
-    if(npos == len)
-    {
-        len = (nullptr != str)?strlen(str):0;
     }
 
-    size_t mem_incr = 0;
-    char* tmp = nullptr;
-    if(0 != len)
+    char string::take_front()
     {
-        if(mem_size < (sz + len + 1))
+        char ret = 0;
+        if(0 < sz)
         {
-            tmp = (char*)realloc(data, (sz + len + 1) * sizeof(char));
-            mem_incr = (sz + len + 1) - mem_size;
-        }
-        else
-        {
-            tmp = data;
-        }
-    }
-
-    if(nullptr != tmp)
-    {
-        if(nullptr != str)
-        {
-            if(len)
+            ret = data[0];
+            sz--;
+            if(0 == sz)
             {
-                memcpy(&tmp[sz], str, len);
+                clear();
             }
-            tmp[sz + len] = 0;
-            sz += len;
+            else
+            {
+                memmove(data, &data[1], sz);
+                data[sz] = 0;
+            }
         }
-        else
+        return ret;
+    }
+
+    size_t string::find(const char* str) const
+    {
+        size_t result = npos;
+        if(valid() && (nullptr != str))
         {
-            memset(&tmp[sz], 0, len * sizeof(char));
+            const char* found = strstr(data, str);
+            if(NULL != found)
+            {
+                result = static_cast<size_t>(found - data);
+            }
         }
-        data = tmp;
-        mem_size += mem_incr;
+        return result;
+    }
+
+    size_t string::find(const char c) const
+    {
+        size_t result = npos;
+        if(valid())
+        {
+            const char* found = strchr(data, static_cast<int>(c));
+            if(NULL != found)
+            {
+                result = static_cast<size_t>(found - data);
+            }
+        }
+        return result;
+    }
+
+    string string::substr (size_t pos, size_t len) const
+    {
+        if(sz <= pos)
+        {
+            return string();
+        }
+        if(sz < (pos + len))
+        {
+            len = sz - pos;
+        }
+        return string(&data[pos], len);
+    }
+
+    void string::append(const char* str, size_t len)
+    {
+        if(npos == len)
+        {
+            len = (nullptr != str)?strlen(str):0;
+        }
+
+        size_t mem_incr = 0;
+        char* tmp = nullptr;
+        if(0 != len)
+        {
+            if(mem_size < (sz + len + 1))
+            {
+                tmp = (char*)realloc(data, (sz + len + 1) * sizeof(char));
+                mem_incr = (sz + len + 1) - mem_size;
+            }
+            else
+            {
+                tmp = data;
+            }
+        }
+
+        if(nullptr != tmp)
+        {
+            if(nullptr != str)
+            {
+                if(len)
+                {
+                    memcpy(&tmp[sz], str, len);
+                }
+                tmp[sz + len] = 0;
+                sz += len;
+            }
+            else
+            {
+                memset(&tmp[sz], 0, len * sizeof(char));
+            }
+            data = tmp;
+            mem_size += mem_incr;
 #ifdef DEBUG_STRING
-        stringMem += mem_incr;
+            stringMem += mem_incr;
 #endif
-    }
-}
-
-void string::append(const string& str)
-{
-    append(str.data, str.size());
-}
-
-StringList string::split(char sep, bool keepSeparator) const
-{
-    StringList ret;
-    size_t last_pos = 0;
-    for(size_t i = 0; i < sz; ++i)
-    {
-        if(data[i] == sep)
-        {
-            if(i > last_pos)
-            {
-                ret.append(substr(last_pos, (i - last_pos)));
-                last_pos = i;
-            }
-            if(keepSeparator)
-            {
-                ret.append(substr(last_pos, 1));
-            }
-            last_pos++;
         }
     }
-    if((0 < last_pos) && (sz > last_pos))
-    {
-        ret.append(substr(last_pos));
-    }
-    if(ret.isEmpty())
-    {
-        ret.append(substr());
-    }
-    return ret;
-}
 
-StringList string::split(const char* sep, bool keepSeparator) const
-{
-    StringList ret;
-    if(nullptr != sep)
+    void string::append(const string& str)
     {
+        append(str.data, str.size());
+    }
+
+    StringList string::split(char sep, bool keepSeparator) const
+    {
+        StringList ret;
         size_t last_pos = 0;
-        size_t sep_len = strlen(sep);
-        if(0 < sep_len)
+        for(size_t i = 0; i < sz; ++i)
+        {
+            if(data[i] == sep)
+            {
+                if(i > last_pos)
+                {
+                    ret.append(substr(last_pos, (i - last_pos)));
+                    last_pos = i;
+                }
+                if(keepSeparator)
+                {
+                    ret.append(substr(last_pos, 1));
+                }
+                last_pos++;
+            }
+        }
+        if((0 < last_pos) && (sz > last_pos))
+        {
+            ret.append(substr(last_pos));
+        }
+        if(ret.isEmpty())
+        {
+            ret.append(substr());
+        }
+        return ret;
+    }
+
+    StringList string::split(const char* sep, bool keepSeparator) const
+    {
+        StringList ret;
+        if(nullptr != sep)
+        {
+            size_t last_pos = 0;
+            size_t sep_len = strlen(sep);
+            if(0 < sep_len)
+            {
+                for(size_t i = 0; i < sz; ++i)
+                {
+                    for(size_t j = 0; j < sep_len; ++j)
+                    {
+                        if(data[i] == sep[j])
+                        {
+                            if(i > last_pos)
+                            {
+                                ret.append(substr(last_pos, (i - last_pos)));
+                                last_pos = i;
+                            }
+                            if(keepSeparator)
+                            {
+                                ret.append(substr(last_pos, 1));
+                            }
+                            last_pos++;
+                            break;
+                        }
+                    }
+                }
+                if((0 < last_pos) && (sz > last_pos))
+                {
+                    ret.append(substr(last_pos));
+                }
+            }
+        }
+        if(ret.isEmpty())
+        {
+            ret.append(substr());
+        }
+        return ret;
+    }
+
+    bool string::compareNoCase(const char* str) const
+    {
+        bool ret = false;
+        if(valid() && (nullptr != str))
+        {
+            ret = (0 == strcmp(string(str).toLower().c_str(), toLower().c_str()));
+        }
+        else
+        {
+            if((nullptr == str) && (0 == sz))
+            {
+                ret = true;
+            }
+        }
+        return ret;
+    }
+
+    size_t string::copy(char* dest, size_t len) const
+    {
+        size_t i = 0;
+        if((nullptr != dest) && (0 < len))
+        {
+            while((i < len) && (i < sz))
+            {
+                dest[i] = data[i];
+                ++i;
+            }
+            dest[i] = 0;
+        }
+        return i;
+    }
+
+    size_t string::copy(unsigned char* dest, size_t len) const
+    {
+        size_t i = 0;
+        if((nullptr != dest) && (0 < len))
+        {
+            while((i < len) && (i < sz))
+            {
+                dest[i] = static_cast<unsigned char>(data[i]);
+                ++i;
+            }
+            dest[i] = 0;
+        }
+        return i;
+    }
+
+    void string::clear()
+    {
+        if(NULL != data)
+        {
+            free(data);
+            data = NULL;
+#ifdef DEBUG_STRING
+            stringMem -= (sz + 1);
+#endif
+            sz = 0;
+            mem_size = 0;
+        }
+    }
+
+    string string::toHex() const
+    {
+        string ret;
+        for(size_t i = 0; i < sz; ++i)
+        {
+            char hiNib = c2h((static_cast<unsigned char>(data[i]) >> 4) & 0x0f);
+            ret.push_back(hiNib);
+            char loNib = c2h(static_cast<unsigned char>(data[i]) & 0x0f);
+            ret.push_back(loNib);
+        }
+        return ret;
+    }
+
+    string string::join(StringList list, size_t pos, size_t len)
+    {
+        string ret;
+        if(npos == len)
+        {
+            len = list.count();
+        }
+        for(size_t i = pos; i < len; ++i)
+        {
+            ret.append(list[i]);
+        }
+        return ret;
+    }
+
+    string string::fromHex(const char* hex)
+    {
+        string ret;
+        size_t len = strlen(hex);
+        size_t i = 0;
+        while(i < len)
+        {
+            char c = (h2c(hex[i++]) << 4);
+            if(i < len)
+            {
+                c |= h2c(hex[i++]);
+            }
+            ret.push_back(c);
+        }
+        return ret;
+    }
+
+    string string::Printf(const char* format, ...)
+    {
+        char buffer[PRINTF_BUFFER_SIZE];
+        va_list vl;
+        va_start(vl, format);
+        int n = vsnprintf((char*)buffer, PRINTF_BUFFER_SIZE, format, vl);
+        va_end(vl);
+        string ret;
+        if((0 < n) && (PRINTF_BUFFER_SIZE > (unsigned int)n))
+        {
+            ret = string(buffer, static_cast<size_t>(n));
+        }
+        return ret;
+    }
+
+    bool string::check7bit() const
+    {
+        bool ret = true;
+        size_t i = 0;
+        while( i < sz )
+        {
+            if((0x20 > data[i]) || (0x7e < data[i]))
+            {
+                ret = false;
+                break;
+            }
+            ++i;
+        }
+        return ret;
+    }
+
+    string string::toLower() const
+    {
+        string ret;
+        for(size_t i = 0; i < sz; ++i)
+        {
+            ret.push_back(static_cast<char>(tolower(static_cast<int>(data[i]))));
+        }
+        return ret;
+    }
+
+    string string::strip(char c) const
+    {
+        size_t len = sz;
+        size_t pos = 0;
+        if(0 < sz)
         {
             for(size_t i = 0; i < sz; ++i)
             {
-                for(size_t j = 0; j < sep_len; ++j)
+                if(c == data[i])
                 {
-                    if(data[i] == sep[j])
-                    {
-                        if(i > last_pos)
-                        {
-                            ret.append(substr(last_pos, (i - last_pos)));
-                            last_pos = i;
-                        }
-                        if(keepSeparator)
-                        {
-                            ret.append(substr(last_pos, 1));
-                        }
-                        last_pos++;
-                        break;
-                    }
+                    ++pos;
+                    --len;
+                }
+                else
+                {
+                    break;
                 }
             }
-            if((0 < last_pos) && (sz > last_pos))
+
+            for(size_t i = (sz - 1); i >= 0; --i)
             {
-                ret.append(substr(last_pos));
+                if(c == data[i])
+                {
+                    --len;
+                }
+                else
+                {
+                    break;
+                }
             }
         }
+        return substr(pos, len);
     }
-    if(ret.isEmpty())
-    {
-        ret.append(substr());
-    }
-    return ret;
-}
 
-bool string::compareNoCase(const char* str) const
-{
-    bool ret = false;
-    if(valid() && (nullptr != str))
+    void string::dup(const char* str, size_t len)
     {
-        ret = (0 == strcmp(string(str).toLower().c_str(), toLower().c_str()));
-    }
-    else
-    {
-        if((nullptr == str) && (0 == sz))
+        clear();
+        if(npos == len)
         {
-            ret = true;
+            len = (nullptr == str)?0:strlen(str);
         }
-    }
-    return ret;
-}
-
-size_t string::copy(char* dest, size_t len) const
-{
-    size_t i = 0;
-    if((nullptr != dest) && (0 < len))
-    {
-        while((i < len) && (i < sz))
+        data = (char*)malloc((len + 1) * sizeof(char));
+        if(NULL != data)
         {
-            dest[i] = data[i];
-            ++i;
-        }
-        dest[i] = 0;
-    }
-    return i;
-}
-
-size_t string::copy(unsigned char* dest, size_t len) const
-{
-    size_t i = 0;
-    if((nullptr != dest) && (0 < len))
-    {
-        while((i < len) && (i < sz))
-        {
-            dest[i] = static_cast<unsigned char>(data[i]);
-            ++i;
-        }
-        dest[i] = 0;
-    }
-    return i;
-}
-
-void string::clear()
-{
-    if(NULL != data)
-    {
-        free(data);
-        data = NULL;
+            if(nullptr != str)
+            {
+                memcpy(data, str, len);
+                data[len] = 0;
+                sz = len;
+            }
+            else
+            {
+                memset(data, 0, (len + 1) * sizeof(char));
+                sz = 0;
+            }
+            mem_size = (len + 1);
 #ifdef DEBUG_STRING
-        stringMem -= (sz + 1);
+            stringMem += (len + 1);
 #endif
-        sz = 0;
-        mem_size = 0;
-    }
-}
-
-string string::toHex() const
-{
-    string ret;
-    for(size_t i = 0; i < sz; ++i)
-    {
-        char hiNib = c2h((static_cast<unsigned char>(data[i]) >> 4) & 0x0f);
-        ret.push_back(hiNib);
-        char loNib = c2h(static_cast<unsigned char>(data[i]) & 0x0f);
-        ret.push_back(loNib);
-    }
-    return ret;
-}
-
-string string::join(StringList list, size_t pos, size_t len)
-{
-    string ret;
-    if(npos == len)
-    {
-        len = list.count();
-    }
-    for(size_t i = pos; i < len; ++i)
-    {
-        ret.append(list[i]);
-    }
-    return ret;
-}
-
-string string::fromHex(const char* hex)
-{
-    string ret;
-    size_t len = strlen(hex);
-    size_t i = 0;
-    while(i < len)
-    {
-        char c = (h2c(hex[i++]) << 4);
-        if(i < len)
-        {
-            c |= h2c(hex[i++]);
         }
-        ret.push_back(c);
     }
-    return ret;
-}
-
-string string::Printf(const char* format, ...)
-{
-    char buffer[PRINTF_BUFFER_SIZE];
-    va_list vl;
-    va_start(vl, format);
-    int n = vsnprintf((char*)buffer, PRINTF_BUFFER_SIZE, format, vl);
-    va_end(vl);
-    string ret;
-    if((0 < n) && (PRINTF_BUFFER_SIZE > (unsigned int)n))
-    {
-        ret = string(buffer, static_cast<size_t>(n));
-    }
-    return ret;
-}
-
-bool string::check7bit() const
-{
-    bool ret = true;
-    size_t i = 0;
-    while( i < sz )
-    {
-        if((0x20 > data[i]) || (0x7e < data[i]))
-        {
-            ret = false;
-            break;
-        }
-        ++i;
-    }
-    return ret;
-}
-
-string string::toLower() const
-{
-    string ret;
-    for(size_t i = 0; i < sz; ++i)
-    {
-        ret.push_back(static_cast<char>(tolower(static_cast<int>(data[i]))));
-    }
-    return ret;
-}
-
-void string::dup(const char* str, size_t len)
-{
-    clear();
-    if(npos == len)
-    {
-        len = (nullptr == str)?0:strlen(str);
-    }
-    data = (char*)malloc((len + 1) * sizeof(char));
-    if(NULL != data)
-    {
-        if(nullptr != str)
-        {
-            memcpy(data, str, len);
-            data[len] = 0;
-            sz = len;
-        }
-        else
-        {
-            memset(data, 0, (len + 1) * sizeof(char));
-            sz = 0;
-        }
-        mem_size = (len + 1);
-#ifdef DEBUG_STRING
-        stringMem += (len + 1);
-#endif
-    }
-}
 
 }


### PR DESCRIPTION
- Include strip function in nbiotstring
- Fix for new B657 firmware, where AT-Commands now require quotation marks and some answers have new quotation marks